### PR TITLE
feat(chart): add GatewayAPI HTTPRoute support

### DIFF
--- a/charts/cyberchef/templates/httproute.yaml
+++ b/charts/cyberchef/templates/httproute.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.httpRoute.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "cyberchef.fullname" . }}
+  labels:
+    {{- include "cyberchef.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.httpRoute.parentRefs | nindent 4 }}
+  {{- if .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml .Values.httpRoute.hostnames | nindent 4 }}
+  {{- end }}
+  rules:
+    - backendRefs:
+        - name: {{ include "cyberchef.fullname" . }}
+          port: {{ .Values.service.port }}
+{{- end }}

--- a/charts/cyberchef/values.yaml
+++ b/charts/cyberchef/values.yaml
@@ -56,6 +56,17 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+
+# Gateway API HTTPRoute — alternative to Ingress for clusters running nginx-gateway-fabric
+# or another Gateway API implementation.
+httpRoute:
+  enabled: false
+  parentRefs: []
+  #  - name: nginx-gateway
+  #    namespace: nginx-gateway
+  hostnames: []
+  #  - cyberchef.example.com
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
Adds an optional HTTPRoute resource (disabled by default) as an alternative to Ingress for clusters running a Gateway API implementation such as nginx-gateway-fabric.